### PR TITLE
Respect CC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,17 @@ matrix:
       env: PYTHONPATH=$PWD
 
 
+    - os: osx
+      osx_image: xcode8.3
+      python: "3.6-dev"
+      before_install:
+        - brew install gcc@8
+      env:
+        - PYTHONPATH=$PWD
+        - CC=gcc-8
+        - CXX=g++-8
+
+
 script:
   - pip install -e .
   - py.test -svx test.py

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,14 @@ class specialized_build_ext(build_ext, object):
             command = 'make'
             if clang:
                 command += ' OPENMP=0'
+
+            env_vars = ['CC', 'CXX', 'CFLAGS', 'FC']
+
+            for v in env_vars:
+                val = os.getenv(v)
+                if val is not None:
+                    command += ' %s=%s'%(v, val)
+
             distutils_logger.info('Will execute the following command in with subprocess.Popen: \n{0}'.format(command))
             try:
                 output = subprocess.check_output(command,


### PR DESCRIPTION
The current install system does not seem to respect the CC environment variable and insists on using the `gcc` executable (whatever it might map to in the environment) to compile the zfp sources. This breaks when `gcc` maps to clang (not supporting openmp) and CC is set to use a different executable that supports openmp (example `gcc-8`)

This PR aims to first reproduce that issue on CI and then fix it. 