### PR TITLE
Fix dimension order for partial decompression

### DIFF
--- a/pyzfp.pyx
+++ b/pyzfp.pyx
@@ -161,9 +161,9 @@ cdef zfp_field* init_field(np.ndarray indata):
     if numdims == 1:
         return zfp_field_1d(raw_pointer(indata), data_type, shape[0])
     elif numdims == 2:
-        return zfp_field_2d(raw_pointer(indata), data_type, shape[0], shape[1])
+        return zfp_field_2d(raw_pointer(indata), data_type, shape[1], shape[0])
     elif numdims == 3:
-        return zfp_field_3d(raw_pointer(indata), data_type, shape[0], shape[1], shape[2])
+        return zfp_field_3d(raw_pointer(indata), data_type, shape[2], shape[1], shape[0])
     #elif numdims == 4:
     #    return zfp_field_4d(raw_pointer(indata), data_type, shape[0], shape[1], shape[2], shape[4])
     else:

--- a/test.py
+++ b/test.py
@@ -10,5 +10,12 @@ def test_compress_decompress():
     assert(a.shape == recovered.shape)
     assert(np.allclose(a, recovered))
 
+def test_dim_order():
+    a = np.arange(32, dtype=np.float32).reshape((8,4))
+    compressed = compress(a, rate=8)
+    recovered = decompress(compressed[0:16], (4,4), np.dtype('float32'), rate=8)
+    b = np.arange(16, dtype=np.float32).reshape((4,4))
+    assert(np.allclose(recovered,b))
 
 test_compress_decompress()
+test_dim_order()


### PR DESCRIPTION
zfp docs have: zfp_field_2d(void* pointer, zfp_type type, uint nx, uint ny) but numpy has fastest changing dimension *last* in .shape attribute.

Compressing/decompressing the a whole array does work without this fix (but may suffer loss of precision as 4x4 or 4x4x4 blocks are not necessarily spatially close to each other). However, decompressing specific subsets of an array doesn't work prior to fix. See test case.