### PR TITLE
Pass OPENMP flag to compiler correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-OPENMP = 0
+export ZFP_WITH_OPENMP=$(OPENMP)
 zfp-0.5.5/lib/libzfp.so: zfp-0.5.5
-	cd zfp-0.5.5 && make ZFP_WITH_OPENMP=$(OPENMP)
+	cd zfp-0.5.5 && $(MAKE)
 
 zfp-0.5.5: 
 	git clone -b release0.5.5 https://github.com/LLNL/zfp.git zfp-0.5.5

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,8 @@ class specialized_build_ext(build_ext, object):
             command = 'make'
             if clang:
                 command += ' OPENMP=0'
+            else:
+                command += ' OPENMP=1'
 
             env_vars = ['CC', 'CXX', 'CFLAGS', 'FC']
 


### PR DESCRIPTION
Passing OPENMP flag through to compiler correctly gives a major speed increase in compression. See https://www.gnu.org/software/make/manual/html_node/Recursion.html