### PR TITLE
fix: add 4D compression and fix C vs. F dimensions

### DIFF
--- a/pyzfp.pyx
+++ b/pyzfp.pyx
@@ -164,8 +164,8 @@ cdef zfp_field* init_field(np.ndarray indata):
         return zfp_field_2d(raw_pointer(indata), data_type, shape[1], shape[0])
     elif numdims == 3:
         return zfp_field_3d(raw_pointer(indata), data_type, shape[2], shape[1], shape[0])
-    #elif numdims == 4:
-    #    return zfp_field_4d(raw_pointer(indata), data_type, shape[0], shape[1], shape[2], shape[4])
+    elif numdims == 4:
+       return zfp_field_4d(raw_pointer(indata), data_type, shape[3], shape[2], shape[1], shape[0])
     else:
         raise ValueError("Invalid number of dimensions (valid: 1-4)")
 

--- a/pyzfp.pyx
+++ b/pyzfp.pyx
@@ -221,7 +221,7 @@ def decompress(const unsigned char[::1] compressed, shape, dtype, tolerance=None
     assert(order.upper() in ('C', 'F'))
     outdata = np.zeros(shape, dtype=dtype, order=order)
     data_type = zfp_types[dtype]
-    shape = list(reversed(shape))
+    
     field = init_field(outdata)
     stream = zfp_stream_open(NULL)
 

--- a/pyzfp.pyx
+++ b/pyzfp.pyx
@@ -157,15 +157,24 @@ zfp_types = {np.dtype('float32'): zfp_type_float, np.dtype('float64'): zfp_type_
 cdef zfp_field* init_field(np.ndarray indata):
     data_type = zfp_types[indata.dtype]
     numdims = len((<object> indata).shape)
-    shape = indata.shape
+
+    # Had to do this awkward construction
+    # because list(indata.shape) had an error.
+    shape = []
+    for i in range(indata.ndim):
+      shape.append(indata.shape[i])
+
+    if indata.flags.c_contiguous:
+      shape = shape[::-1]
+
     if numdims == 1:
         return zfp_field_1d(raw_pointer(indata), data_type, shape[0])
     elif numdims == 2:
-        return zfp_field_2d(raw_pointer(indata), data_type, shape[1], shape[0])
+        return zfp_field_2d(raw_pointer(indata), data_type, shape[0], shape[1])
     elif numdims == 3:
-        return zfp_field_3d(raw_pointer(indata), data_type, shape[2], shape[1], shape[0])
+        return zfp_field_3d(raw_pointer(indata), data_type, shape[0], shape[1], shape[2])
     elif numdims == 4:
-       return zfp_field_4d(raw_pointer(indata), data_type, shape[3], shape[2], shape[1], shape[0])
+       return zfp_field_4d(raw_pointer(indata), data_type, shape[0], shape[1], shape[2], shape[3])
     else:
         raise ValueError("Invalid number of dimensions (valid: 1-4)")
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ def extensions():
                                   numpy.get_include()],
                     libraries=["zfp"],  # Unix-like specific,
                     library_dirs=["zfp-0.5.5/lib"],
+                    language='c',
                     # extra_link_args=['-Wl,-rpath,/usr/local/lib']
                     )
     return cythonize([ext])

--- a/test.py
+++ b/test.py
@@ -43,12 +43,15 @@ def test_dim_order(order):
         b = np.arange(16, dtype=np.float32).reshape((4, 4), order=order)
     elif order == "F":
         b = np.array(
-            [[ 0,  8, 16, 24],
-             [ 1,  9, 17, 25],
-             [ 2, 10, 18, 26],
-             [ 3, 11, 19, 27]], 
+            [[0,  8, 16, 24],  # noqa: E201
+             [1,  9, 17, 25],  # noqa: E201
+             [2, 10, 18, 26],
+             [3, 11, 19, 27]],
             dtype=np.float32, order="F")
     assert(np.allclose(recovered, b))
 
-    recovered = decompress(compressed, (8,4), np.dtype('float32'), rate=8, order=order)
+    recovered = decompress(
+        compressed, (8, 4), np.dtype('float32'),
+        rate=8, order=order
+    )
     assert(np.allclose(recovered, a))

--- a/test.py
+++ b/test.py
@@ -39,5 +39,16 @@ def test_dim_order(order):
     compressed = compress(a, rate=8)
     recovered = decompress(compressed[0:16], (4, 4), np.dtype('float32'),
                            rate=8, order=order)
-    b = np.arange(16, dtype=np.float32).reshape((4, 4), order=order)
+    if order == "C":
+        b = np.arange(16, dtype=np.float32).reshape((4, 4), order=order)
+    elif order == "F":
+        b = np.array(
+            [[ 0,  8, 16, 24],
+             [ 1,  9, 17, 25],
+             [ 2, 10, 18, 26],
+             [ 3, 11, 19, 27]], 
+            dtype=np.float32, order="F")
     assert(np.allclose(recovered, b))
+
+    recovered = decompress(compressed, (8,4), np.dtype('float32'), rate=8, order=order)
+    assert(np.allclose(recovered, a))


### PR DESCRIPTION
This PR adds back in the commented out 4D compression and ensures C and F dimensions are handled correctly as described here:

https://zfp.readthedocs.io/en/latest/issues.html#p-dimensions